### PR TITLE
Switch from config folder to native traefik folder

### DIFF
--- a/config/traefik/traefik.yml
+++ b/config/traefik/traefik.yml
@@ -18,7 +18,7 @@ services:
       - 8090:8080
     volumes:
        - /var/run/docker.sock:/var/run/docker.sock:ro
-       - /share/appdata/config/traefik:/etc/traefik
+       - /share/appdata/traefik:/etc/traefik
     networks:
       - traefik_public
     deploy:


### PR DESCRIPTION
Since traefik is looking on startup for traefik.toml and traefik.yml/yaml it should be better to use a separate folder.