### PR TITLE
Add redirect to http to https

### DIFF
--- a/config/traefik/traefik.yml
+++ b/config/traefik/traefik.yml
@@ -25,10 +25,19 @@ services:
       placement:
         constraints: [node.role == manager]
       labels:
+        # Catch all incoming requests on HTTP and redirect to HTTPS
+        - "traefik.http.routers.http-catchall.rule=hostregexp(`{host:[a-z-.]+}`)"
+        - "traefik.http.routers.http-catchall.entrypoints=http"
+        - "traefik.http.routers.http-catchall.middlewares=https-redirect@file"      
+        
+        # listen for https requests and use forward auth.
+        # Terminate SSL, whoami doesnt listen on SSL traffic, whoami is listening on plain text unencrypted http connections.
+        # https://docs.traefik.io/v2.0/routing/routers/#tls
         - "traefik.enable=true"
         - "traefik.http.routers.dashboard.rule=Host(`traefik.gkoerk.com`)"
         - "traefik.http.routers.dashboard.tls.certresolver=namecheap"
-        - "traefik.http.routers.dashboard.middlewares=secured@file"
+        - "traefik.http.routers.dashboard.middlewares=forward-auth@file"
+        - "traefik.http.routers.dashboard.entrypoints=https"
         - "traefik.http.services.dashboard.loadbalancer.server.port=8080"
 
   whoami:
@@ -40,8 +49,8 @@ services:
         - "traefik.enable=true"
         - "traefik.http.routers.whoami.rule=Host(`whoami.gkoerk.com`)"
         - "traefik.http.routers.whoami.tls.certresolver=namecheap"
-        - "traefik.http.routers.whoami.middlewares=secured@file"      
-        - "traefik.http.services.whoami.loadbalancer.server.port=80"
+        - "traefik.http.routers.whoami.entrypoints=https"
+        - "traefik.http.routers.whoami.middlewares=forward-auth@file"      
        
   auth:
     image: dniel/forwardauth:latest
@@ -61,8 +70,8 @@ services:
         - "traefik.enable=true"
         - "traefik.http.routers.auth.rule=Host(`auth.gkoerk.com`)" 
         - "traefik.http.routers.auth.tls.certresolver=namecheap"
-        - "traefik.http.routers.auth.middlewares=secured@file"
-        - "traefik.http.services.auth.loadbalancer.server.port=8080"          
+        - "traefik.http.routers.auth.entrypoints=https"
+        - "traefik.http.routers.auth.middlewares=forward-auth@file"
         
   www:
     image: dniel/blogr-www
@@ -72,9 +81,8 @@ services:
       labels:
         - "traefik.enable=true"
         - "traefik.http.routers.www.rule=Host(`www.gkoerk.com`)"
-        - "traefik.http.routers.www.middlewares=secured@file"      
-        - "traefik.http.routers.www.middlewares=secured@file"      
-        - "traefik.http.services.www.loadbalancer.server.port=80"
+        - "traefik.http.routers.www.middlewares=forward-auth@file"   
+        - "traefik.http.routers.www.entrypoints=https"
       
 networks:
   traefik_public:


### PR DESCRIPTION
- Added catch all rule for HTTP on traefik router
- Removed port specification from container that use the default exposed. Should only be needed to specify port to load balance on services that has more than one port.
- added entrypoint definition to routers to explicitly listen on https, this is most for clarity, it would work without as well.

I also hope that "traefik.http.routers.XXX.tls.certresolver" does terminate the SSL connection in traefik like "traefik.http.routers.XXX.tls" the services does not listen on encrypted connections, they accept traffic from traefik on unencrypted http conncetions. SSL Passthrough should only be used if the endpoint in the service supports SSL I think.